### PR TITLE
Fix router errors on php server launch

### DIFF
--- a/router.php
+++ b/router.php
@@ -15,6 +15,13 @@ $uri = ($uri === '') ? '/' : $uri;
 
 log_debug("Processing URI: '$uri'");
 
+// Fix URLs that start with /public/assets/ by redirecting to /assets/
+if (str_starts_with($uri, '/public/assets/')) {
+    $corrected_uri = str_replace('/public/assets/', '/assets/', $uri);
+    log_debug("Correcting asset URL from '$uri' to '$corrected_uri'");
+    $uri = $corrected_uri;
+}
+
 // Routing table
 $routes = [
     '/login'             => '/backend/auth/login.php',

--- a/router_debug.log
+++ b/router_debug.log
@@ -2131,3 +2131,21 @@
 [2025-07-26 13:31:59] Processing URI: '/'
 [2025-07-26 13:31:59] Attempting to load: /workspace/public/index.html
 [2025-07-26 13:31:59] File found - including: /workspace/public/index.html
+[2025-07-26 13:32:40] === NEW REQUEST ===
+[2025-07-26 13:32:40] REQUEST_URI: /
+[2025-07-26 13:32:40] Processing URI: '/'
+[2025-07-26 13:32:40] Attempting to load: /workspace/public/index.html
+[2025-07-26 13:32:40] File found - including: /workspace/public/index.html
+[2025-07-26 13:32:46] === NEW REQUEST ===
+[2025-07-26 13:32:46] REQUEST_URI: /assets/css/Home.css
+[2025-07-26 13:32:46] Processing URI: '/assets/css/Home.css'
+[2025-07-26 13:32:46] Static file check - Requested: /workspace/public/assets/css/Home.css
+[2025-07-26 13:32:46] Static file check - Resolved: /workspace/public/assets/css/Home.css
+[2025-07-26 13:32:46] Serving static file: /workspace/public/assets/css/Home.css
+[2025-07-26 13:32:53] === NEW REQUEST ===
+[2025-07-26 13:32:53] REQUEST_URI: /public/assets/css/Home.css
+[2025-07-26 13:32:53] Processing URI: '/public/assets/css/Home.css'
+[2025-07-26 13:32:53] Correcting asset URL from '/public/assets/css/Home.css' to '/assets/css/Home.css'
+[2025-07-26 13:32:53] Static file check - Requested: /workspace/public/assets/css/Home.css
+[2025-07-26 13:32:53] Static file check - Resolved: /workspace/public/assets/css/Home.css
+[2025-07-26 13:32:53] Serving static file: /workspace/public/assets/css/Home.css

--- a/router_debug.log
+++ b/router_debug.log
@@ -2126,3 +2126,8 @@
 [2025-07-25 14:58:38] Static file check - Requested: C:\Users\gsais\Downloads\ICSPL-P/public/assets/css/services.css
 [2025-07-25 14:58:38] Static file check - Resolved: C:\Users\gsais\Downloads\ICSPL-P\public\assets\css\services.css
 [2025-07-25 14:58:38] Serving static file: C:\Users\gsais\Downloads\ICSPL-P\public\assets\css\services.css
+[2025-07-26 13:31:59] === NEW REQUEST ===
+[2025-07-26 13:31:59] REQUEST_URI: /
+[2025-07-26 13:31:59] Processing URI: '/'
+[2025-07-26 13:31:59] Attempting to load: /workspace/public/index.html
+[2025-07-26 13:31:59] File found - including: /workspace/public/index.html

--- a/router_debug.log
+++ b/router_debug.log
@@ -2149,3 +2149,21 @@
 [2025-07-26 13:32:53] Static file check - Requested: /workspace/public/assets/css/Home.css
 [2025-07-26 13:32:53] Static file check - Resolved: /workspace/public/assets/css/Home.css
 [2025-07-26 13:32:53] Serving static file: /workspace/public/assets/css/Home.css
+[2025-07-26 13:43:18] === NEW REQUEST ===
+[2025-07-26 13:43:18] REQUEST_URI: /
+[2025-07-26 13:43:18] Processing URI: '/'
+[2025-07-26 13:43:18] Attempting to load: /workspace/public/index.html
+[2025-07-26 13:43:18] File found - including: /workspace/public/index.html
+[2025-07-26 13:43:27] === NEW REQUEST ===
+[2025-07-26 13:43:27] REQUEST_URI: /assets/css/Home.css
+[2025-07-26 13:43:27] Processing URI: '/assets/css/Home.css'
+[2025-07-26 13:43:27] Static file check - Requested: /workspace/public/assets/css/Home.css
+[2025-07-26 13:43:27] Static file check - Resolved: /workspace/public/assets/css/Home.css
+[2025-07-26 13:43:27] Serving static file: /workspace/public/assets/css/Home.css
+[2025-07-26 13:43:34] === NEW REQUEST ===
+[2025-07-26 13:43:34] REQUEST_URI: /public/assets/css/Home.css
+[2025-07-26 13:43:34] Processing URI: '/public/assets/css/Home.css'
+[2025-07-26 13:43:34] Correcting asset URL from '/public/assets/css/Home.css' to '/assets/css/Home.css'
+[2025-07-26 13:43:34] Static file check - Requested: /workspace/public/assets/css/Home.css
+[2025-07-26 13:43:34] Static file check - Resolved: /workspace/public/assets/css/Home.css
+[2025-07-26 13:43:34] Serving static file: /workspace/public/assets/css/Home.css


### PR DESCRIPTION
Add URL correction to `router.php` to resolve inconsistent asset paths.

HTML files were referencing assets with `/public/assets/` (e.g., `/public/assets/js/services.js`), which caused the router to incorrectly look for files at `/public/public/assets/`. This change ensures that such URLs are correctly mapped to `/assets/`, fixing 404 errors for static assets.

---

[Open in Web](https://cursor.com/agents?id=bc-76bc7b83-1587-4d8a-af76-63549fc8e230) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-76bc7b83-1587-4d8a-af76-63549fc8e230) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)